### PR TITLE
Implements select metric to StartAutoMLRequest

### DIFF
--- a/Adapter_pb2_grpc.py
+++ b/Adapter_pb2_grpc.py
@@ -6,7 +6,9 @@ import Adapter_pb2 as Adapter__pb2
 
 
 class AdapterServiceStub(object):
-    """Missing associated documentation comment in .proto file."""
+    """
+    AutoML Adapter Service implementation. Service provide functionality to execute and interact with the current AutoML process.
+    """
 
     def __init__(self, channel):
         """Constructor.
@@ -22,10 +24,14 @@ class AdapterServiceStub(object):
 
 
 class AdapterServiceServicer(object):
-    """Missing associated documentation comment in .proto file."""
+    """
+    AutoML Adapter Service implementation. Service provide functionality to execute and interact with the current AutoML process.
+    """
 
     def StartAutoML(self, request, context):
-        """Missing associated documentation comment in .proto file."""
+        """
+        Execute a new AutoML run. 
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
@@ -46,7 +52,9 @@ def add_AdapterServiceServicer_to_server(servicer, server):
 
  # This class is part of an EXPERIMENTAL API.
 class AdapterService(object):
-    """Missing associated documentation comment in .proto file."""
+    """
+    AutoML Adapter Service implementation. Service provide functionality to execute and interact with the current AutoML process.
+    """
 
     @staticmethod
     def StartAutoML(request,

--- a/AutoMLs/StructuredDataAutoML.py
+++ b/AutoMLs/StructuredDataAutoML.py
@@ -34,6 +34,10 @@ class StructuredDataAutoML(object):
         if self.__configuration["runtime_constraints"]["max_iter"] == 0:
             self.__configuration["runtime_constraints"]["max_iter"] = 3
 
+        if self.__configuration["metric"] == "":
+            # handle empty metric field, None is the default metric parameter for AutoKeras
+            self.__configuration["metric"] = None
+
     def __read_training_data(self):
         """
         Read the training dataset from disk
@@ -86,6 +90,7 @@ class StructuredDataAutoML(object):
         self.__dataset_preparation()
         clf = ak.StructuredDataClassifier(overwrite=True,
                                           max_trials=self.__configuration["runtime_constraints"]["max_iter"],
+                                          metric=self.__configuration['metric'],
                                           seed=42)
         clf.fit(x=self.__X, y=self.__y)
         self.__export_model(clf)
@@ -96,6 +101,7 @@ class StructuredDataAutoML(object):
         self.__dataset_preparation()
         reg = ak.StructuredDataRegressor(overwrite=True,
                                          max_trials=self.__configuration["runtime_constraints"]["max_iter"],
+                                         metric=self.__configuration['metric'],
                                          seed=42)
         reg.fit(x=self.__X, y=self.__y)
         self.__export_model(reg)


### PR DESCRIPTION
[#22](https://github.com/hochschule-darmstadt/MetaAutoML/issues/22) implements a new parameter "metric" in the grpc files and the adapters. This metric parameter is used to set the metric the adapter should optimize for. If the field is kept empty each adapter uses its default value.